### PR TITLE
Updated to work with more recent Webpack.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(), // don't reload if there is an error
+    new webpack.NoEmitOnErrorsPlugin(), // don't reload if there is an error
     new BundleTracker({path: __dirname, filename: './webpack-stats.json'})
   ],
 
@@ -24,7 +24,7 @@ module.exports = {
     {
       test: /\.jsx$/,
       exclude: /(node_modules|bower_components)/,
-      loader: 'babel', // 'babel-loader' is also a legal name to reference
+      loader: 'babel-loader', 
       query: {
         presets: ['es2015', 'react']
       }
@@ -34,7 +34,7 @@ module.exports = {
 },
 
   resolve: {
-    modulesDirectories: ['node_modules', 'bower_components'],
-    extensions: ['', '.js', '.jsx']
+    modules: ['node_modules', 'bower_components'],
+    extensions: ['.js', '.jsx']
   },
 }


### PR DESCRIPTION
It removes the following 4 errors/warnings from Webpack 2.6.1

WARNING in webpack: Using NoErrorsPlugin is deprecated. Use NoEmitOnErrorsPlugin instead.
Module build failed: Error: The node API for `babel` has been moved to `babel-core`.
- configuration.resolve has an unknown property 'modulesDirectories'. T
- configuration.resolve.extensions[0] should not be empty.